### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/de/bundle_visitor.rs
+++ b/src/de/bundle_visitor.rs
@@ -80,7 +80,7 @@ impl<'de, 'a, R> de::Deserializer<'de> for BundleField<'a, R>
     {
         match self {
             BundleField::TimeTag((sec, frac)) =>
-                visitor.visit_seq(IterVisitor([sec, frac].into_iter().cloned()
+                visitor.visit_seq(IterVisitor([sec, frac].iter().cloned()
                     .map(PrimDeserializer))),
             BundleField::Elements(mut read) =>
                 visitor.visit_seq(ElemAccessor{ read }),


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
