### PR TITLE
Add support for non-streamed OSC packets

### DIFF
--- a/examples/to_from_vec.rs
+++ b/examples/to_from_vec.rs
@@ -5,7 +5,7 @@ extern crate serde_bytes;
 extern crate serde_osc;
 
 use serde_bytes::ByteBuf;
-use serde_osc::{de, ser};
+use serde_osc::{de, ser, Framing};
 
 /// Struct we'll serialize.
 /// This represents a single OSC message with three arguments:
@@ -31,11 +31,10 @@ fn main() {
     println!("Serializing {:?}", message);
 
     // Serialize the message to an OSC packet stored in a Vec<u8>
-    let as_vec = ser::to_vec(&message).unwrap();
+    let as_vec = ser::to_vec(&message, Framing::Unframed).unwrap();
     println!("Serialied to: {:?}", as_vec);
 
     // Deserialize an OSC packet contained in a Vec<u8> into the Message struct
-    let received: Message = de::from_slice(&as_vec).unwrap();
+    let received: Message = de::from_slice(&as_vec, Framing::Unframed).unwrap();
     println!("Received: {:?}", received);
 }
-

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -35,8 +35,6 @@ pub fn from_read<'de, D, R>(mut rd: R, framing: Framing) -> ResultE<D>
             buffer.write(tempbuffer.as_slice())?;
             buffer.seek(SeekFrom::Start(0))?;
 
-            println!("{:?}", buffer);
-
             let mut de = Deserializer::new(&mut buffer);
             D::deserialize(&mut de)
         }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -33,6 +33,9 @@ pub fn from_read<'de, D, R>(mut rd: R, framing: Framing) -> ResultE<D>
             let buflen = rd.read_to_end(&mut tempbuffer)?;
             buffer.write_i32::<BigEndian>(buflen.try_into()?)?;
             buffer.write(tempbuffer.as_slice())?;
+            buffer.seek(SeekFrom::Start(0))?;
+
+            println!("{:?}", buffer);
 
             let mut de = Deserializer::new(&mut buffer);
             D::deserialize(&mut de)

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,4 +1,5 @@
-use std::io::{Cursor, Read};
+use std::{convert::TryInto, io::{Cursor, Read, Seek, SeekFrom, Write}};
+use byteorder::{BigEndian, WriteBytesExt};
 use serde;
 use error::ResultE;
 
@@ -12,22 +13,39 @@ mod osc_type;
 mod pkt_deserializer;
 mod prim_deserializer;
 
+use crate::Framing;
+
 pub use self::pkt_deserializer::PktDeserializer as Deserializer;
 
 /// Deserialize an OSC packet from some readable device.
-pub fn from_read<'de, D, R>(mut rd: R) -> ResultE<D>
+pub fn from_read<'de, D, R>(mut rd: R, framing: Framing) -> ResultE<D>
     where R: Read, D: serde::de::Deserialize<'de>
 {
-    let mut de = Deserializer::new(&mut rd);
-    D::deserialize(&mut de)
+    match framing {
+        Framing::Framed => {
+            let mut de = Deserializer::new(&mut rd);
+            D::deserialize(&mut de)
+        },
+        Framing::Unframed => {
+            let mut buffer = Cursor::new(Vec::new());
+
+            let mut tempbuffer: Vec<u8> = Vec::new();
+            let buflen = rd.read_to_end(&mut tempbuffer)?;
+            buffer.write_i32::<BigEndian>(buflen.try_into()?)?;
+            buffer.write(tempbuffer.as_slice())?;
+
+            let mut de = Deserializer::new(&mut buffer);
+            D::deserialize(&mut de)
+        }
+    }
 }
 
 
 /// Deserialize an OSC packet from a `&[u8]` type.
 /// This is a wrapper around the `from_read` function.
 /// Pairs nicely with ser::to_vec, as Vec<u8> is coercable to &[u8].
-pub fn from_slice<'de, T>(slice: &[u8]) -> ResultE<T>
+pub fn from_slice<'de, T>(slice: &[u8], framing: Framing) -> ResultE<T>
     where T: serde::de::Deserialize<'de>
 {
-    from_read(Cursor::new(slice))
+    from_read(Cursor::new(slice), framing)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,3 +100,8 @@ pub mod ser;
 
 pub use de::{from_read, from_slice};
 pub use ser::{to_write, to_vec};
+
+pub enum Framing {
+    Unframed,
+    Framed
+}

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Write};
+use std::{convert::TryInto, io::{Cursor, Read, Seek, SeekFrom, Write}};
 use serde;
 use error::ResultE;
 
@@ -12,24 +12,43 @@ mod osc_writer;
 mod msg_serializer;
 mod timetag_ser;
 
-pub use self::pkt_serializer::PktSerializer as Serializer;
+use super::ser::osc_writer::OscWriter;
+use crate::Framing;
 
+pub use self::pkt_serializer::PktSerializer as Serializer;
 /// Serialize `value` into an OSC packet, and write the contents into `write`.
 /// Note that serialization of structs is done only based on the ordering
 /// of fields; their names are not preserved in the output.
-pub fn to_write<S: ?Sized, W: Write>(write: &mut W, value: &S) -> ResultE<()>
+pub fn to_write<S: ?Sized, W: Write>(write: &mut W, value: &S, framing: Framing) -> ResultE<()>
     where W: Write, S: serde::ser::Serialize
 {
-    let mut ser = Serializer::new(write.by_ref());
-    value.serialize(&mut ser)
+    match framing {
+        Framing::Unframed => {
+            let mut ser = Serializer::new(write.by_ref());
+            value.serialize(&mut ser)
+        },
+        Framing::Framed => {
+            let mut buffer = Cursor::new(Vec::new());
+            let mut ser = Serializer::new(&mut buffer);
+            value.serialize(&mut ser)?;
+            // get buffer length
+            let buflen = buffer.seek(SeekFrom::End(0))?;
+            buffer.seek(SeekFrom::Start(0))?;
+            write.osc_write_i32(buflen.try_into()?)?;
+            let mut tempbuf = vec![0 as u8; buflen.try_into()?];
+            buffer.read(tempbuf.as_mut_slice())?;
+            write.write(tempbuf.as_slice())?;
+            Ok(())
+        }
+    }
 }
 
 /// Serializes `value` into a `Vec<u8>` type.
 /// This is a wrapper around the `to_write` function.
-pub fn to_vec<T: ?Sized>(value: &T) -> ResultE<Vec<u8>>
+pub fn to_vec<T: ?Sized>(value: &T, framing: Framing) -> ResultE<Vec<u8>>
     where T: serde::ser::Serialize
 {
     let mut output = Cursor::new(Vec::new());
-    to_write(&mut output, value)?;
+    to_write(&mut output, value, framing)?;
     Ok(output.into_inner())
 }

--- a/src/ser/msg_serializer.rs
+++ b/src/ser/msg_serializer.rs
@@ -39,8 +39,6 @@ impl MsgSerializer {
             return Err(Error::BadFormat);
         }
 
-        // Write the packet length
-        output.osc_write_i32(payload_size.try_into()?)?;
         // Write the address and type tag
         output.write_all(&typetag)?;
         let zeros = b"\0\0\0\0";
@@ -62,22 +60,22 @@ impl<'a> Serializer for &'a mut MsgSerializer {
     type SerializeStructVariant = Impossible<Self::Ok, Error>;
 
     fn serialize_seq(
-        self, 
+        self,
         _size: Option<usize>
     ) -> ResultE<Self::SerializeSeq>
     {
         Ok(ArgSerializer{ msg: self })
     }
     fn serialize_tuple(
-        self, 
+        self,
         size: usize
     ) -> ResultE<Self::SerializeTuple>
     {
         self.serialize_seq(Some(size))
     }
     fn serialize_struct(
-        self, 
-        _: &'static str, 
+        self,
+        _: &'static str,
         size: usize
     ) -> ResultE<Self::SerializeStruct>
     {

--- a/tests/de/auto_derive.rs
+++ b/tests/de/auto_derive.rs
@@ -1,5 +1,5 @@
 use serde_bytes::ByteBuf;
-use serde_osc::de;
+use serde_osc::{de, Framing};
 
 
 #[test]
@@ -22,7 +22,7 @@ fn auto_de() {
     // Note: 0x43dc0000 is 440.0 in f32.
     let test_input = b"\x00\x00\x00\x2C/example/path\0\0\0,ifb\0\0\0\0\x01\x02\x03\x04\x43\xdc\0\0\0\0\0\x05\xde\xad\xbe\xef\xff\x00\x00\x00";
 
-    let deserialized: Deserialized = de::from_slice(test_input).unwrap();
+    let deserialized: Deserialized = de::from_slice(test_input, Framing::Framed).unwrap();
     assert_eq!(deserialized, expected);
 }
 
@@ -30,7 +30,7 @@ fn auto_de() {
 fn to_tuple() {
     let expected = ("/ts".to_owned(), ());
     let test_input = b"\x00\x00\x00\x08/ts\0,\0\0\0";
-    let deserialized: (String, ()) = de::from_slice(test_input).unwrap();
+    let deserialized: (String, ()) = de::from_slice(test_input, Framing::Framed).unwrap();
     assert_eq!(deserialized, expected);
 }
 
@@ -38,7 +38,7 @@ fn to_tuple() {
 fn to_array() {
     let expected: (String, [i32; 0]) = ("/ts".to_owned(), []);
     let test_input = b"\x00\x00\x00\x08/ts\0,\0\0\0";
-    let deserialized: (String, [i32; 0]) = de::from_slice(test_input).unwrap();
+    let deserialized: (String, [i32; 0]) = de::from_slice(test_input, Framing::Framed).unwrap();
     assert_eq!(deserialized, expected);
 }
 
@@ -49,7 +49,6 @@ fn to_unit_struct() {
 
     let expected: (String, Unit) = ("/ts".to_owned(), Unit);
     let test_input = b"\x00\x00\x00\x08/ts\0,\0\0\0";
-    let deserialized: (String, Unit) = de::from_slice(test_input).unwrap();
+    let deserialized: (String, Unit) = de::from_slice(test_input, Framing::Framed).unwrap();
     assert_eq!(deserialized, expected);
 }
-

--- a/tests/de/bundle.rs
+++ b/tests/de/bundle.rs
@@ -1,4 +1,4 @@
-use serde_osc::de;
+use serde_osc::{de, Framing};
 
 #[test]
 fn bundle() {
@@ -34,6 +34,6 @@ fn bundle() {
     // Note: 0x43dc0000 is 440.0 in f32.
     let test_input = b"\x00\x00\x00\x30#bundle\0\x01\x02\x03\x04\x05\x06\x07\x08\x00\x00\x00\x0C/m1\0,i\0\0\x5E\xEE\xEE\xED\x00\x00\x00\x0C/m2\0,f\0\0\x43\xdc\x00\x00";
 
-    let deserialized: Bundle = de::from_slice(test_input).unwrap();
+    let deserialized: Bundle = de::from_slice(test_input, Framing::Framed).unwrap();
     assert_eq!(deserialized, expected);
 }

--- a/tests/ser/tuple.rs
+++ b/tests/ser/tuple.rs
@@ -17,7 +17,7 @@ fn tuple_ser() {
     );
 
     // Note: 0x43dc0000 is 440.0 in f32.
-    let expected = b"\x00\x00\x00\x2C/example/path\0\0\0,ifb\0\0\0\0\x01\x02\x03\x04\x43\xdc\0\0\0\0\0\x05\xde\xad\xbe\xef\xff\x00\x00\x00".to_vec();
+    let expected = b"/example/path\0\0\0,ifb\0\0\0\0\x01\x02\x03\x04\x43\xdc\0\0\0\0\0\x05\xde\xad\xbe\xef\xff\x00\x00\x00".to_vec();
     let mut output = Cursor::new(Vec::new());
 
     {
@@ -34,7 +34,7 @@ fn unit_ser() {
         "/ts".to_owned(), ()
     );
 
-    let expected = b"\x00\x00\x00\x08/ts\0,\0\0\0".to_vec();
+    let expected = b"/ts\0,\0\0\0".to_vec();
     let mut output = Cursor::new(Vec::new());
 
     {


### PR DESCRIPTION
Removes the length based on requirement for non-streamed OSC packets.

Fixes #3 

TODO:
- [ ] fix bundling
- [ ] update tests